### PR TITLE
JobScheduler needs to be destroyed after used in specs.

### DIFF
--- a/spec/controllers/job_schedule_groups_controller_spec.rb
+++ b/spec/controllers/job_schedule_groups_controller_spec.rb
@@ -158,6 +158,8 @@ RSpec.describe JobScheduleGroupsController, :type => :controller do
           JobScheduler.new.start_scheduler
         end
 
+        after { JobScheduler.find.destroy }
+
         it 'updates associated job_specs' do
           expect {
             put :update, {:id => @job_schedule_group.to_param, :job_schedule_group => @updated_attributes}, valid_session
@@ -202,6 +204,8 @@ RSpec.describe JobScheduleGroupsController, :type => :controller do
         @job_spec = FactoryGirl.create(:job_spec, job_schedule_group: @job_schedule_group, enabled: true)
         JobScheduler.new.start_scheduler
       end
+
+      after { JobScheduler.find.destroy }
 
       it 'unschedules the job_specs associated with the destroyed job_schedule_group' do
         expect {

--- a/spec/controllers/job_specs_controller_spec.rb
+++ b/spec/controllers/job_specs_controller_spec.rb
@@ -135,6 +135,8 @@ RSpec.describe JobSpecsController, :type => :controller do
         JobScheduler.new.start_scheduler
       end
 
+      after { JobScheduler.find.destroy }
+
       it 'updates the scheduler' do
         new_attributes = @job_spec.attributes.merge(:job_schedule_group_id => @new_job_schedule.id)
 
@@ -195,6 +197,8 @@ RSpec.describe JobSpecsController, :type => :controller do
         @job_spec = FactoryGirl.create(:job_spec, :schedule_in_1s, enabled: true)
         JobScheduler.new.start_scheduler
       end
+
+      after { JobScheduler.find.destroy }
 
       it 'unschedules the destroyed job spec' do
         expect {

--- a/spec/support/birst_soap.rb
+++ b/spec/support/birst_soap.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
     savon.mock!
 
     stub_request(:get, "https://app2102.bws.birst.com/CommandWebService.asmx?WSDL")
-      .with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'HTTPClient/1.0 (2.4.0, ruby 2.0.0 (2013-11-22))'})
+      .with(:headers => {'Accept'=>'*/*'})
       .to_return(:status => 200, :body => File.open(File.join(Rails.root, 'spec/support/birst_soap_wsdl_app2102_5_13.xml')).read, :headers => {})
   end
 


### PR DESCRIPTION
This was causing some specs to fail when not run in isolation.
