### PR TITLE
BugFix - Duplicate space was not honoring checkboxes

### DIFF
--- a/app/models/job_spec.rb
+++ b/app/models/job_spec.rb
@@ -1,7 +1,7 @@
 class JobSpec < ActiveRecord::Base
-  nilify_blanks
 
   after_initialize :defaults, unless: :persisted?
+  nilify_blanks
 
   job_template_types_prod = %w(TplBirstSoapGenericCommand TplBirstDuplicateSpace TplBirstStagedRefresh)
   job_template_types_test = %w(TplDevTest)
@@ -14,7 +14,7 @@ class JobSpec < ActiveRecord::Base
   validates_presence_of :name
 
   belongs_to :job_template, polymorphic: true, dependent: :destroy, inverse_of: :job_spec
-  accepts_nested_attributes_for :job_template, reject_if: :all_blank
+  accepts_nested_attributes_for :job_template
 
   belongs_to :job_schedule_group
   belongs_to :client
@@ -23,7 +23,7 @@ class JobSpec < ActiveRecord::Base
 
 
   def defaults
-    self.enabled = true if self.enabled.blank?
+    self.enabled = true if self.enabled.nil?
   end
 
   def build_job_template(params)

--- a/app/models/tpl_birst_duplicate_space.rb
+++ b/app/models/tpl_birst_duplicate_space.rb
@@ -3,6 +3,7 @@ class TplBirstDuplicateSpace < ActiveRecord::Base
 
   JOB_SPEC_PERMITTED_ATTRIBUTES = 
     [
+      :id,
       :from_space_id_str, 
       :to_space_name, 
       :with_membership, 
@@ -20,9 +21,9 @@ class TplBirstDuplicateSpace < ActiveRecord::Base
   after_initialize :defaults, unless: :persisted?
 
   def defaults
-    self.with_membership = true if self.with_membership.blank?
-    self.with_data = true if self.with_data.blank?
-    self.with_datastore = true if self.with_datastore.blank?
+    self.with_membership = true if self.with_membership.nil?
+    self.with_data = true if self.with_data.nil?
+    self.with_datastore = true if self.with_datastore.nil?
   end
 
   extend Amylase::JobInitializers

--- a/app/models/tpl_birst_soap_generic_command.rb
+++ b/app/models/tpl_birst_soap_generic_command.rb
@@ -1,7 +1,7 @@
 class TplBirstSoapGenericCommand < ActiveRecord::Base
   nilify_blanks
 
-  JOB_SPEC_PERMITTED_ATTRIBUTES = [:command, :argument_json]
+  JOB_SPEC_PERMITTED_ATTRIBUTES = [:id, :command, :argument_json]
 
   validates_presence_of :command
   has_one :job_spec, as: :job_template

--- a/app/models/tpl_birst_staged_refresh.rb
+++ b/app/models/tpl_birst_staged_refresh.rb
@@ -3,6 +3,7 @@ class TplBirstStagedRefresh < ActiveRecord::Base
 
   JOB_SPEC_PERMITTED_ATTRIBUTES =
     [
+      :id,
       :data_source_collection_id,
       :birst_process_group_collection_id,
       :production_space_id,

--- a/app/models/tpl_dev_test.rb
+++ b/app/models/tpl_dev_test.rb
@@ -1,7 +1,7 @@
 class TplDevTest < ActiveRecord::Base
   nilify_blanks
 
-  JOB_SPEC_PERMITTED_ATTRIBUTES = [ :argument ]
+  JOB_SPEC_PERMITTED_ATTRIBUTES = [ :id, :argument ]
   
   validates_presence_of :argument
   has_one :job_spec, as: :job_template

--- a/app/views/job_specs/_tpl_birst_duplicate_space.html.erb
+++ b/app/views/job_specs/_tpl_birst_duplicate_space.html.erb
@@ -1,4 +1,5 @@
 <%= f.simple_fields_for :job_template_attributes, form_job_template_object(@job_spec, 'TplBirstDuplicateSpace') do |tpl| %>
+  <%= tpl.input :id, as: :hidden, input_html: { name: 'job_spec[tpl_birst_duplicate_space][id]' } %>
   <%= tpl.input :from_space_id_str %>
   <%= tpl.input :to_space_name %>
 

--- a/app/views/job_specs/_tpl_birst_soap_generic_command.html.erb
+++ b/app/views/job_specs/_tpl_birst_soap_generic_command.html.erb
@@ -1,4 +1,5 @@
 <%= f.simple_fields_for :job_template_attributes, form_job_template_object(@job_spec, 'TplBirstSoapGenericCommand') do |tpl| %>
+  <%= tpl.input :id, as: :hidden, input_html: { name: 'job_spec[tpl_birst_soap_generic_command][id]' } %>
   <%= tpl.input :command %>
   <%= tpl.input :argument_json %>
 <% end %>

--- a/app/views/job_specs/_tpl_birst_staged_refresh.html.erb
+++ b/app/views/job_specs/_tpl_birst_staged_refresh.html.erb
@@ -1,4 +1,5 @@
 <%= f.simple_fields_for :job_template_attributes, form_job_template_object(@job_spec, 'TplBirstStagedRefresh') do |tpl| %>
+  <%= tpl.input :id, as: :hidden, input_html: { name: 'job_spec[tpl_birst_staged_refresh][id]' } %>
   <%= tpl.association :production_space, collection: BirstSpace.order(:name), include_blank: 'Default' %>
   <%= tpl.association :staging_space, collection: BirstSpace.order(:name), include_blank: 'Default' %>
   <%= tpl.association :data_source_collection, collection: DataSourceCollection.order(:name), include_blank: 'Default - None' %>

--- a/spec/features/tpl_birst_duplicate_space_features_spec.rb
+++ b/spec/features/tpl_birst_duplicate_space_features_spec.rb
@@ -1,0 +1,65 @@
+# spec/features/tpl_birst_duplicate_space_features_spec.rb
+
+require 'rails_helper'
+
+feature 'user interacts with the TplBirstDuplicateSpace JobSpec form', :js => true do
+  before { Capybara.current_driver = :webkit }
+  after { Capybara.use_default_driver }
+
+  feature 'to create a new TplBirstDuplicateSpace job' do
+    before do
+      visit new_job_spec_path
+      fill_in 'Name', with: 'the_george_job'
+      check 'Enabled'
+      select 'TplBirstDuplicateSpace', from: 'Job template type'
+      fill_in 'From space id str', with: SecureRandom.uuid
+      fill_in 'To space name', with: 'george_II'
+      check 'With data'
+    end
+
+    context 'with valid data' do
+      scenario 'the creation was successful' do
+        click_button 'Create Job spec'
+
+        expect(page).to have_content 'Success! JobSpec created.'
+        expect(page).to have_content 'the_george_job'
+        expect(page).to have_content 'job_template_type: TplBirstDuplicateSpace'
+      end
+    end
+
+    context 'with invalid data' do
+      scenario 'the creation was unsuccessful' do
+        fill_in 'From space id str', with: 'not a valid UUI'
+        click_button 'Create Job spec'
+
+        expect(page).to have_content 'Error! JobSpec not created'
+        expect(page).to have_content 'space id must be a UUID'
+      end
+    end
+  end
+
+  feature 'to edit an existing TplBirstDuplicateSpace job' do
+    before do
+      @tpl = FactoryGirl.create(:tpl_birst_duplicate_space, with_membership: false, with_data: true)
+      @job_spec = FactoryGirl.create(:job_spec, job_template: @tpl)
+
+      visit edit_job_spec_path @job_spec
+    end
+
+    scenario 'unchecking an option' do
+      expect(@job_spec.job_template.with_data).to be true
+
+      uncheck 'With data'
+      click_button 'Update Job spec'
+
+      expect(page).to have_content 'Success! JobSpec updated'
+      
+      @job_spec.reload
+      expect(@job_spec.job_template_id).to eq @tpl.id
+      expect(@job_spec.job_template.with_data).to be false
+    end
+    
+  end
+end
+
+


### PR DESCRIPTION
Two issues were at work here.  The first was that false.blank? evaluates to true, so the way that
the defaults were being set in models/tpl_birst_duplicate_space would override the user if they
unchecked a box.  The second more difficult problem to solve was that each time the job template
was being updated via the job_spec view, it was creating a new job template id.  Fixing it required
adding the job_template_id as a hidden form element and finagling the params creation
in the controller.
