### PR TITLE
BugFix - New LaunchJob id

### DIFF
--- a/spec/support/spec_support.rb
+++ b/spec/support/spec_support.rb
@@ -1,0 +1,10 @@
+module SpecSupport
+  def self.wait_for(msg, interval = 0.3, max_iter = 20, &condition)
+    iter = 0
+    until condition.call || iter >= max_iter
+      sleep interval
+      iter += 1
+    end
+    raise "#{msg} wait timed out" if iter >= max_iter
+  end
+end


### PR DESCRIPTION
There was an issue where the LaunchedJob id was being reused each time the
Scheduler ran the job.  This wasn't detected in initial tests because they would
start and stop the scheduler between Rufus runs.  This fix creates a new JobHandler
in the LaunchedJob namespace that creates a new LaunchedJob instance each
time Rufus executes the job.
