### PR TITLE
FIX - Passive FTP mode

### DIFF
--- a/app/models/tpl_gooddata_extract.rb
+++ b/app/models/tpl_gooddata_extract.rb
@@ -141,6 +141,7 @@ class TplGooddataExtract < ActiveRecord::Base
     job_log.info "Connecting to FTP host #{self.destination_host} with username #{self.destination_credential.username}"
     Net::FTP.open(self.destination_host) do |ftp|
       ftp.login(self.destination_credential.username, self.destination_credential.password)
+      ftp.passive
 
       job_log.info "chdir #{self.destination_folder}"
       ftp.chdir(self.destination_folder)

--- a/spec/models/tpl_gooddata_extract_spec.rb
+++ b/spec/models/tpl_gooddata_extract_spec.rb
@@ -244,6 +244,7 @@ RSpec.describe TplGooddataExtract, :type => :model do
         ftp = double('Ftp server', :null_object => true)
         expect(Net::FTP).to receive(:open).once.and_yield(ftp)
         expect(ftp).to receive(:login).once.with(@tpl.destination_credential.username, @tpl.destination_credential.password)
+        expect(ftp).to receive(:passive).once
         expect(ftp).to receive(:chdir).once.with(@tpl.destination_folder)
         @files_hash.each do |remote_file, local_file|
           expect(ftp).to receive(:putbinaryfile).with(local_file, @tpl.with_timestamp(remote_file))


### PR DESCRIPTION
I was running into issues using FTP only when running in elastic beanstalk.  Some research
revealed that using passive mode is needed when running behind a firewall.